### PR TITLE
Add JSON endpoints for tables

### DIFF
--- a/app/controllers/table_controller.rb
+++ b/app/controllers/table_controller.rb
@@ -42,6 +42,10 @@ class TableController < ApplicationController
   private
 
   def set_columns
-    @columns = @table.columns.map(&:name)
+    @columns = @table.columns.map(&:name).excluding(columns_to_exclude)
+  end
+
+  def columns_to_exclude
+    params[:exclude] || []
   end
 end

--- a/app/controllers/table_controller.rb
+++ b/app/controllers/table_controller.rb
@@ -2,20 +2,46 @@ class TableController < ApplicationController
   def movies
     @records = Movie.all.paginate(page: params[:page], per_page: 8)
     @table = Movie
+    set_columns
+    respond_to do |format|
+      format.html
+      format.json { render "index" }
+    end
   end
   
   def directors
     @records = Director.all.paginate(page: params[:page], per_page: 8)
     @table = Director
+    set_columns
+    respond_to do |format|
+      format.html
+      format.json { render "index" }
+    end
   end
   
   def actors
     @records = Actor.all.paginate(page: params[:page], per_page: 8)
     @table = Actor
+    set_columns
+    respond_to do |format|
+      format.html
+      format.json { render "index" }
+    end
   end
   
   def characters
     @records = Character.all.paginate(page: params[:page], per_page: 8)
     @table = Character
+    set_columns
+    respond_to do |format|
+      format.html
+      format.json { render "index" }
+    end
+  end
+
+  private
+
+  def set_columns
+    @columns = @table.columns.map(&:name)
   end
 end

--- a/app/views/table/_table.json.jbuilder
+++ b/app/views/table/_table.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! table, *columns

--- a/app/views/table/index.json.jbuilder
+++ b/app/views/table/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @records, partial: "table/table", locals: {columns: @columns.map(&:to_sym)}, as: :table


### PR DESCRIPTION
## Problem

While re-working the UI for levelup, having to use an iframe to embed the records is restrictive.

Primarily it doesn't allow some columns to be hidden if they are not relevant to the current level.

## Solution

Respond to JSON requests and allow columns to be excluded.

```
/table/movies.json?exclude[]=director_id
```
